### PR TITLE
Add TweetClaw purchase-intention CSV converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ This project leverages **Twitter data** and **machine learning** to predict whet
 
 ---
 
+## Optional TweetClaw Export Preparation
+
+Use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) exports as reviewed
+source material when you need fresh X/Twitter examples in the same `class,text`
+schema used by `data/Annotated4.csv`.
+
+```bash
+python scripts/tweetclaw_to_purchase_intention_csv.py exports/tweetclaw-phone.jsonl data/tweetclaw_purchase_intention.csv --class-label yes
+```
+
+Only append rows after reviewing each exported post and choosing the `yes` or
+`no` purchase-intention label it should carry in model training or testing.
+
+---
+
 ## ⚙️ Setting Up Dependencies
 
 Make sure you have **Python (latest version)** installed, then install the required packages.

--- a/scripts/tweetclaw_to_purchase_intention_csv.py
+++ b/scripts/tweetclaw_to_purchase_intention_csv.py
@@ -1,0 +1,114 @@
+"""Convert reviewed TweetClaw exports into purchase-intention CSV rows."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+TEXT_FIELDS = ("text", "tweet_text", "tweet", "full_text", "content", "body")
+FIELDNAMES = ("class", "text")
+CLASS_LABELS = ("yes", "no")
+
+
+def read_export(path: str | Path) -> list[dict[str, object]]:
+    source = Path(path)
+    content = source.read_text(encoding="utf-8-sig").strip()
+    if not content:
+        return []
+
+    suffix = source.suffix.lower()
+    if suffix == ".csv":
+        return _read_csv_rows(content)
+    if suffix in {".jsonl", ".ndjson"}:
+        return _read_json_lines(content)
+    if content[0] in "[{":
+        return _rows_from_payload(json.loads(content))
+    return _read_json_lines(content)
+
+
+def convert_rows(
+    rows: Iterable[dict[str, object]],
+    class_label: str,
+) -> Iterable[dict[str, str]]:
+    for row in rows:
+        text = _first_text(row)
+        if not text:
+            continue
+        yield {
+            "class": class_label,
+            "text": normalize_text(text),
+        }
+
+
+def write_csv(rows: Iterable[dict[str, str]], output_path: str | Path) -> None:
+    with Path(output_path).open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", str(text)).strip()
+
+
+def _read_csv_rows(content: str) -> list[dict[str, object]]:
+    first_line = content.splitlines()[0]
+    delimiter = ";" if first_line.count(";") > first_line.count(",") else ","
+    return [dict(row) for row in csv.DictReader(content.splitlines(), delimiter=delimiter)]
+
+
+def _read_json_lines(content: str) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _rows_from_payload(payload: object) -> list[dict[str, object]]:
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        for key in ("results", "tweets", "items", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [row for row in value if isinstance(row, dict)]
+        return [payload]
+    return []
+
+
+def _first_text(row: dict[str, object]) -> str:
+    for field in TEXT_FIELDS:
+        value = row.get(field)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert reviewed TweetClaw exports into class,text CSV rows."
+    )
+    parser.add_argument("input", help="TweetClaw JSON, JSONL, NDJSON, or CSV export.")
+    parser.add_argument("output", help="Output CSV path for the model pipeline.")
+    parser.add_argument(
+        "--class-label",
+        required=True,
+        choices=CLASS_LABELS,
+        help="Reviewed purchase-intention label to apply to every exported row.",
+    )
+    args = parser.parse_args()
+
+    write_csv(convert_rows(read_export(args.input), args.class_label), args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tweetclaw_to_purchase_intention_csv.py
+++ b/tests/test_tweetclaw_to_purchase_intention_csv.py
@@ -1,0 +1,70 @@
+"""Tests for TweetClaw purchase-intention export conversion."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "tweetclaw_to_purchase_intention_csv.py"
+)
+SPEC = importlib.util.spec_from_file_location("tweetclaw_converter", MODULE_PATH)
+assert SPEC is not None
+tweetclaw_converter = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(tweetclaw_converter)
+
+
+class TestTweetClawToPurchaseIntentionCsv(unittest.TestCase):
+    def test_jsonl_export_converts_to_project_schema(self) -> None:
+        source_path = self._write_file(
+            "\n".join(
+                [
+                    json.dumps({"text": "I will buy the new phone tomorrow."}),
+                    json.dumps({"full_text": "Not buying this model yet."}),
+                ]
+            ),
+            ".jsonl",
+        )
+
+        rows = list(
+            tweetclaw_converter.convert_rows(tweetclaw_converter.read_export(source_path), "yes")
+        )
+
+        self.assertEqual(rows[0]["class"], "yes")
+        self.assertEqual(rows[0]["text"], "I will buy the new phone tomorrow.")
+        self.assertEqual(rows[1]["text"], "Not buying this model yet.")
+
+    def test_csv_export_writes_header(self) -> None:
+        source_path = self._write_file("tweet_text\nNeed to buy this phone\n", ".csv")
+        output_path = Path(tempfile.NamedTemporaryFile(delete=False, suffix=".csv").name)
+
+        tweetclaw_converter.write_csv(
+            tweetclaw_converter.convert_rows(tweetclaw_converter.read_export(source_path), "no"),
+            output_path,
+        )
+
+        with output_path.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+
+        self.assertEqual(rows[0]["class"], "no")
+        self.assertEqual(rows[0]["text"], "Need to buy this phone")
+
+    def test_rows_without_text_are_skipped(self) -> None:
+        rows = list(tweetclaw_converter.convert_rows([{"created_at": "2026-06-20"}], "yes"))
+
+        self.assertEqual(rows, [])
+
+    def _write_file(self, content: str, suffix: str) -> Path:
+        handle = tempfile.NamedTemporaryFile("w", delete=False, suffix=suffix, encoding="utf-8")
+        with handle:
+            handle.write(content)
+        return Path(handle.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dependency-free converter for reviewed TweetClaw JSON, JSONL, NDJSON, and CSV exports
- write rows in the existing class,text schema used by the purchase-intention datasets
- require an explicit reviewed yes or no class label before rows can be appended
- document the optional TweetClaw export preparation workflow and add unittest coverage

## Validation
- python3 -m py_compile scripts/tweetclaw_to_purchase_intention_csv.py tests/test_tweetclaw_to_purchase_intention_csv.py
- python3 -m unittest discover tests
- python3 -m black --check --line-length 100 scripts/tweetclaw_to_purchase_intention_csv.py tests/test_tweetclaw_to_purchase_intention_csv.py
- CLI smoke conversion from a TweetClaw JSONL row to class,text CSV schema
- git diff --check
- npx --yes markdown-link-check README.md --quiet reports the pre-existing localhost README link; the new TweetClaw link returns HTTP 200